### PR TITLE
Skip Errors Instead of Breaking

### DIFF
--- a/functions/AddFilmReviewInfo.m
+++ b/functions/AddFilmReviewInfo.m
@@ -96,7 +96,10 @@ for i = 1:length(DataFolders)
         end
     save(fullfile(DataFolders{1,i},'00_transformedData.mat'),'impacts')
     ExportImpactsToTable(DataFolders{1,i})
-    ExportPFN(filmReviewFolder, filmReviewFieldname,DataFolders{1,i})
+    
+    if isfield(FILM_REVIEW,filmReviewFieldname) == 1
+        ExportPFN(filmReviewFolder, filmReviewFieldname,DataFolders{1,i})
+    end
     
     clear('impacts')
     masterLoc = fileparts(DataFolders{1,i});

--- a/functions/CombinePFN.m
+++ b/functions/CombinePFN.m
@@ -4,14 +4,16 @@ masterLoc = fileparts(DataFolders{1,1});
 
 PFN_all = {};
 for i = 1:length(DataFolders)
-    load(fullfile(DataFolders{1,i},'01_PFN.mat'))
-    if isempty(PFN) == 0  
-        if(isempty(PFN_all))
-            PFN_all = PFN;
-        else
-            PFN_all = outerjoin(PFN_all,PFN,'MergeKeys',true);
-        end    
-    end
+     if exist(fullfile(DataFolders{1,i},'01_PFN.mat')) == 2
+        load(fullfile(DataFolders{1,i},'01_PFN.mat'))
+        if isempty(PFN) == 0  
+            if(isempty(PFN_all))
+                PFN_all = PFN;
+            else
+                PFN_all = outerjoin(PFN_all,PFN,'MergeKeys',true);
+            end    
+        end
+     end
 end
 
 save(fullfile(masterLoc,'01_PFN.mat'), 'PFN_all');

--- a/functions/CombineTransformedData.m
+++ b/functions/CombineTransformedData.m
@@ -19,6 +19,14 @@ mpAll = [];
     
 for i = 1:length(DataFolders)
     load(fullfile(DataFolders{1,i},'00_transformedData.mat'))
+        if isempty(impacts)
+            msg = cell(4,1);
+            q = strfind(DataFolders{1,i},"\");
+            msg{1,1} = sprintf('WARNING: No real impacts recorded on %s.',DataFolders{1,i}(q(end)+1:length(DataFolders{1,i})));
+            msg{2,1} = sprintf('Run Quality Check for Errors on Date.');
+            errordlg(msg);
+            continue
+        end
     impactsAll = horzcat(impactsAll,impacts);
     for j = 1:length(impacts)
        mp{j} = impacts{1,j}.Info.MouthpieceID;
@@ -73,6 +81,14 @@ else
     
     for i = 1:length(DataFolders)
         load(fullfile(DataFolders{1,i},'00_transformedData.mat'));
+            if isempty(impacts)
+                msg = cell(4,1);
+                q = strfind(DataFolders{1,i},"\");
+                msg{1,1} = sprintf('WARNING: No real impacts recorded on %s.',DataFolders{1,i}(q(end)+1:length(DataFolders{1,i})));
+                msg{2,1} = sprintf('Run Quality Check for Errors on Date.');
+                errordlg(msg);
+                continue
+            end
         time1 = impacts{1,1}.Info.ImpactTime;
         tempInd = find(date == folderDates(i));
         tempTime = time(tempInd);

--- a/functions/GetTransformationInfo.m
+++ b/functions/GetTransformationInfo.m
@@ -49,6 +49,9 @@ for i = 1:length(devices)
         transformationInfo.(devices{i}).r_accel = r_accel;
         transformationInfo.(devices{i}).r_gyro = r_gyro;
     else
+        if length(transformation_file) > 1
+            transformation_file(2:length(transformation_file)) = [];
+        end
         transformation_file = fullfile(transformation_file.folder,transformation_file.name);
         [~,filename,ext] = fileparts(transformation_file);
         


### PR DESCRIPTION
Allows for errors in film review to be found and skipped instead of breaking the code. That way we can find all the missing film reviews and mismatched data in one shot without having to run the code numerous times.

Also fixes an issue if there are two .xls/.xlsx transform files